### PR TITLE
option changes to prinseq trim and some minor bug fixes

### DIFF
--- a/shotcleaner.pl
+++ b/shotcleaner.pl
@@ -611,7 +611,15 @@ sub _run_bowtie2{
 	my $cmd;
 	#do some housekeeping
 	my $read = $reads[$i-1];          
-	my $f_mate = $read;
+	#Begin CGedits
+	my $f_mate;
+	if ( $trim_method_list =~ m/prinseq/ ){
+		$f_mate = "$read.fastq";
+	}else{
+		$f_mate = $read; 
+	} 
+	#my $f_mate = $read;
+	#END cgedits
 	my $f_in  = File::Spec->catfile( $in_dir, $f_mate );
 	my $f_base = basename( $read, @in_suffixes ); #this contains the split value!
 	my $r_in;
@@ -890,7 +898,7 @@ sub _run_prinseq{
 	    #courtney's analysis
 	    #$cmd =  "$prinseq -verbose -derep 14 -derep_min 2 -no_qual_header "; #do we want -exact_only?
 	    $cmd .=  "$prinseq -verbose -no_qual_header "; #do we want -exact_only?
-	    $cmd .= "-min_len 60 -max_len 200 -min_qual_mean 25 -ns_max_n 0 ";
+	    $cmd .= "-min_len 60 -max_len 300 -min_qual_mean 25 -ns_max_n 0 ";
 	    $cmd .= "-lc_method entropy -lc_threshold 60 -trim_qual_left 20 -trim_qual_right 20 ";
 	    if( $paired_end ){
 		$cmd .= "-out_good $out_path -fastq $f_in -fastq2 $r_in -log $log ";
@@ -1001,7 +1009,7 @@ sub _cat_reads{
     } else {
 	@f_sorted    = @sorted;
 	my $out_stem = $f_base;
-	my $out_path = File::Spec->catfile( $result_dir, $out_stem );
+	my $out_path = File::Spec->catfile( $result_dir, $out_stem . ".fq" );
 	print("cat @f_sorted > $out_path\n");
 	system("cat @f_sorted > $out_path");
     }


### PR DESCRIPTION
I have changed the default parameters to prinseq-lite to include support for 300bp reads. I also fixed a bug that resulted in bad file names when running SE reads with the prinseq-lite option. 
