### PR TITLE
Made several bugfixes and updates for newer software.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ fastq, fasta, and fastqc results will be retained, and all files will be gzipped
 Dependencies
 ------------
 
-###Perl Modules
+### Perl Modules ###
 * Carp
 * File::Basename
 * File::Copy
@@ -147,7 +147,7 @@ Dependencies
 * Parallel::ForkManager
 * Getopt::Long
 
-###External Software
+### External Software ###
 * bowtie2
 * bmtagger
 * FastQC

--- a/README.md
+++ b/README.md
@@ -138,20 +138,20 @@ Dependencies
 ------------
 
 ###Perl Modules
-*Carp
-*File::Basename
-*File::Copy
-*File::Path
-*File::Spec
-*File::Spec::Functions
-*Parallel::ForkManager
-*Getopt::Long
+* Carp
+* File::Basename
+* File::Copy
+* File::Path
+* File::Spec
+* File::Spec::Functions
+* Parallel::ForkManager
+* Getopt::Long
 
 ###External Software
-*bowtie2
-*bmtagger
-*FastQC
-*FastUnique
-*prinseq
-*seqret (EMBOSS)
-*trimmomatic
+* bowtie2
+* bmtagger
+* FastQC
+* FastUnique
+* prinseq
+* seqret (EMBOSS)
+* trimmomatic

--- a/inc/App-cpanminus-1.7004/bin/cpanm
+++ b/inc/App-cpanminus-1.7004/bin/cpanm
@@ -1,4 +1,4 @@
-#!perl
+#!/usr/bin/env perl
 #
 # You want to install cpanminus? Run the following command and it will
 # install itself for you. You might want to run it as a root with sudo

--- a/install.pl
+++ b/install.pl
@@ -1,5 +1,6 @@
-#!/usr/bin/perl -w 
+#!/usr/bin/env perl
 
+use warnings;
 use strict;
 use File::Path;
 use File::Spec;
@@ -24,6 +25,7 @@ my $test      = $options->{"test"};
 my $db        = $options->{"db"};
 my $source    = $options->{"source"};
 my $all       = $options->{"all"};
+
 my $iso_alg;
 if( defined( $options->{"iso-alg"} ) ){
     $iso_alg = $options->{"iso-alg"};
@@ -33,32 +35,36 @@ my $dir = _get_root();
 
 our $ROOT = $dir;
 my $root = $ROOT;
+# Remove trailing /
+chop($root);
 
-my $inc = "${root}/inc/"; #location of included source code (cpanm)
-my $pkg = "${root}/pkg/"; #location that we'll place algorithms
-my $ext = "${root}/ext/"; #location of installed external perl modules (separate so we can wipe)
-my $bin = "${root}/bin/"; #location of installed executables (symlinks)
+my $inc = "${root}/inc"; #location of included source code (cpanm)
+my $pkg = "${root}/pkg"; #location that we'll place algorithms
+my $ext = "${root}/ext"; #location of installed external perl modules (separate so we can wipe)
+my $bin = "${root}/bin"; #location of installed executables (symlinks)
+my $lib = "$ext/lib/perl5"; #location of installed perl modules
 
 system( "mkdir -p $pkg" );
 
 ######################
 # Install Perl Module Dependencies using cpanm
 if( $perlmods ){
- my @mods = (
-     "Carp",
-     "File::Basename",
-     "File::Copy",
-     "File::Path",
-     "File::Spec",
-     "File::Spec::Functions",
-     "Parallel::ForkManager",
-     "Getopt::Long",
-     );
- 
- foreach my $mod( @mods ){
-     my $cmd = "perl ${bin}/cpanm -L ${ext} ${mod}";
-     system( $cmd );
- }
+    my @mods = (
+        "Carp",
+        "File::Basename",
+        "File::Copy",
+        "File::Path",
+        "File::Spec",
+        "File::Spec::Functions",
+        "File::Copy::Recursive",
+        "Parallel::ForkManager",
+        "Getopt::Long"
+    );
+
+    foreach my $mod( @mods ){
+        my $cmd = "perl ${bin}/cpanm -L ${ext} ${mod}";
+        system( $cmd );
+    }
 }
 
 ######################
@@ -67,56 +73,55 @@ if( $perlmods ){
 if( $algs ){
     my $alg_data = parse_alg_data( $root . "/installer_alg_data.txt", $source, $test);
     foreach my $alg( keys( %$alg_data ) ){
-	if( defined( $iso_alg ) ){
-	    next if( $alg ne $iso_alg );
-	}
-	my $src   = $alg_data->{$alg}->{"src"};
-	my $stem  = $alg_data->{$alg}->{"stem"};
-	my $links = $alg_data->{$alg}->{"links"};
-	my $build = $alg_data->{$alg}->{"build"};
-	my $bins  = $alg_data->{$alg}->{"bins"};	    
-	my $dload = $alg_data->{$alg}->{"download"};	    
+        if( defined( $iso_alg ) ){
+            next if( $alg ne $iso_alg );
+        }
+        my $src   = $alg_data->{$alg}->{"src"};
+        my $stem  = $alg_data->{$alg}->{"stem"};
+        my $links = $alg_data->{$alg}->{"links"};
+        my $build = $alg_data->{$alg}->{"build"};
+        my $bins  = $alg_data->{$alg}->{"bins"};
+        my $dload = $alg_data->{$alg}->{"download"};
 
-	print "Installing ${alg}...\n";
-	#need a better way to automate this step...
-	my $alg_pkg = "${pkg}/${stem}/";
-	if( $alg eq "blast" && $source ){
-	    $alg_pkg = "${pkg}/${stem}/c++/";
-	}
-	if( $clean ){
-	    clean_src( $links,
-		       $alg_pkg, 
-		       "${pkg}" . basename( $src ) 
-		);
-	}    
-	if( $get ){
-	    get_src( $src, $pkg, $dload );
-	    decompress_src( $pkg, basename( $src ) );
-	}	
-	if( $build ){
-	    unless( $build eq "NA" ){
-		build_src( $alg_pkg, $build );	    
-	    }
-	}	
-	foreach my $target( split( "\;", $bins ) ){
-	    link_src( $alg_pkg . $target, 
-		      $bin );
-	}
-	print "\t...done with ${alg}\n";
+        print "Installing ${alg}...\n";
+        #need a better way to automate this step...
+        my $alg_pkg = "${pkg}/${stem}/";
+        if( $alg eq "blast" && $source ){
+            $alg_pkg = "${pkg}/${stem}/c++/";
+        }
+        if( $clean ){
+            clean_src( $links,
+                       $alg_pkg,
+                       "$pkg/" . basename( $src )
+            );
+        }
+        if( $get ){
+            get_src( $src, "$pkg/", $dload );
+            decompress_src( "$pkg/", basename( $src ) );
+        }
+        if( $build ){
+            unless( $build eq "NA" ){
+            build_src( $alg_pkg, $build );
+            }
+        }
+        foreach my $target( split( "\;", $bins ) ){
+            link_src( $alg_pkg . $target, $bin );
+        }
+        print "\t...done with ${alg}\n";
     }
+
     print( "The requested items have been installed. If you haven't already, please be sure " .
-	   "to make the following additions to your ~/.bash_profile:\n" .
-	   "###################################\n"               . 
-	   "export PATH=\$PATH:${root}/bin/\n"         .
-	   "export PERL5LIB=\$PERL5LIB:${root}/lib/\n" .
-	   "###################################\n" 
-	);
-    print( "If you like, you can copy and paste the following command to automate the above entries:\n" . 
-	   "###################################\n"                                         . 
-	   "echo 'export PATH=\$PATH:${root}/bin/' >> ~/.bash_profile\n"         .
-	   "echo 'export PERL5LIB=\$PERL5LIB:${root}/lib/' >> ~/.bash_profile\n" .
-	   "###################################\n" 
-	);
+           "to make the following additions to your ~/.bash_profile:\n" .
+           "###################################\n" .
+           "export PATH=${bin}:\$PATH\n" .
+           "export PERL5LIB=${lib}:\$PERL5LIB:\n" .
+           "###################################\n");
+
+    print( "If you like, you can copy and paste the following command to automate the above entries:\n" .
+           "###################################\n" .
+           "echo 'export PATH=${bin}:\$PATH' >> ~/.bash_profile\n" .
+           "echo 'export PERL5LIB=${lib}:\$PERL5LIB' >> ~/.bash_profile\n" .
+           "###################################\n");
 }
 
 
@@ -125,7 +130,6 @@ if( $algs ){
 ###############
 ### SUBROUTINES
 
-    
 sub build_src{
     my $loc = shift; #path to the downloaded, decompressed source, relative to shotmap root
     my $cmds =  shift; #semicolon delimited list of commands
@@ -136,8 +140,8 @@ sub build_src{
     my @commands = split( "\;", $cmds );
     print $loc . "\n";
     foreach my $command( @commands ){
-	print "$command\n";
-	system( "$command" );
+        print "$command\n";
+        system( "$command" );
     }
     chdir( $ROOT );
     return;
@@ -146,7 +150,7 @@ sub build_src{
 sub check_name{
     my $name = shift;
     if( ! defined( $name ) ){
-	die "Could not find a name when parsing alg_data!";
+        die "Could not find a name when parsing alg_data!";
     }
 }
 
@@ -157,18 +161,16 @@ sub decompress_src{
     print "decompressing source...\n";
     chdir( $loc );
     #if( ! -e $stem ){
-	#die "For some reason, I didn't download $stem into $loc. " . 
-	#    "Please try to reproduce this error before contacting " . 
-	#    "the author for assistance\n";
+    #die "For some reason, I didn't download $stem into $loc. " .
+    #    "Please try to reproduce this error before contacting " .
+    #    "the author for assistance\n";
     #}
     if( $stem =~ m/\.tar\.gz/ ){
-	system( "tar xzf $stem" );
-    }
-    elsif( $stem =~ m/\.zip/ ){
-	system( "unzip $stem" );
-    }
-    else{
-	warn "No decompression needed for $stem\n";
+        system( "tar xzf $stem" );
+    } elsif( $stem =~ m/\.zip/ ){
+        system( "unzip $stem" );
+    } else{
+        warn "No decompression needed for $stem\n";
     }
     chdir( $ROOT );
     return;
@@ -177,10 +179,10 @@ sub decompress_src{
 sub dereference_options{
     my $options = shift; #hashref
     foreach my $key( keys( %$options )){
-	my $value = $options->{$key};
-	if( defined( $value ) ){
-	    $options->{$key} = ${ $value };
-	}
+        my $value = $options->{$key};
+        if( defined( $value ) ){
+            $options->{$key} = ${ $value };
+        }
     }
     return $options;
 }
@@ -194,18 +196,16 @@ sub get_src{
     print "downloading source...\n";
     chdir( $loc );
     if( $method eq "git" ){
-	system( "git clone $url" );
-    }
-    elsif( $method =~ m/(wget.*)/ ){ #bmtagger requires extra wget options
-	system( "$1 $url" );
-    }
-    else{
-	die( "I don't know how to deal with the download method $method\n");
+        system( "git clone $url" );
+    } elsif( $method =~ m/(wget.*)/ ){ #bmtagger requires extra wget options
+        system( "$1 $url" );
+    } else{
+        die( "I don't know how to deal with the download method $method\n");
     }
     if( $url =~ m/bmtagger/ ){ #need to move it to keep things clean...
-	my $current = $loc . "ftp.ncbi.nlm.nih.gov/pub/agarwala/bmtagger/";
-	my $move_to = $loc . "bmtagger/";
-	system( "mv $current $move_to" );
+        my $current = $loc . "ftp.ncbi.nlm.nih.gov/pub/agarwala/bmtagger/";
+        my $move_to = $loc . "bmtagger/";
+        system( "mv $current $move_to" );
     }
     chdir( $ROOT );
     return;
@@ -218,16 +218,18 @@ sub clean_src{
 
     print "\tcleaning old install...\n";
     foreach my $link( split( "\;", $link_names ) ){
-	print( "removing $link\n" );
-	unlink( $link );
+        print( "removing $link\n" );
+        unlink( $link );
     }
+
     if( -d "${src_dir}" ){
-	rmtree( "${src_dir}" );
+        rmtree( "${src_dir}" );
     }
-    if( defined( $dl_stem )) { 
-	if( -e "${dl_stem}"){
-	    unlink( "${dl_stem}" );
-	}
+
+    if( defined( $dl_stem )){
+        if( -e "${dl_stem}"){
+            unlink( "${dl_stem}" );
+        }
     }
 
     chdir( $ROOT );
@@ -246,72 +248,71 @@ sub get_options{
     my $get       = 0; #download alg source code?
     my $build     = 0; #build alg source code?
     my $test      = 0; #should we run make checks during build?
-    my $db        = 0; #should we install myql libraries? 
-    my $all       = 1; 
+    my $db        = 0; #should we install myql libraries?
+    my $all       = 1;
     my $source    = 0; #should we build from source instead of x86 libraries
     my $iso_alg;       #let's only build one specific algoritm.
 
     my %ops = (
-	"use-db"   => \$db, #try to build the libraries needed for mysql communication
-	"source"   => \$source, #not currently implemented
-	"clean"    => \$clean,
-	"test"     => \$test,
-	"build"    => \$build,
-	"get"      => \$get,
-	"algs"     => \$algs,
-	"rpacks"   => \$rpackages,
-	"perlmods" => \$perlmods,
-	"all"      => \$all,
-	"iso-alg"  => \$iso_alg,
-	);
-    
+        "use-db"   => \$db, #try to build the libraries needed for mysql communication
+        "source"   => \$source, #not currently implemented
+        "clean"    => \$clean,
+        "test"     => \$test,
+        "build"    => \$build,
+        "get"      => \$get,
+        "algs"     => \$algs,
+        "rpacks"   => \$rpackages,
+        "perlmods" => \$perlmods,
+        "all"      => \$all,
+        "iso-alg"  => \$iso_alg,
+    );
+
     my @opt_type_array = (
-	"use-db!",
-	"source!",
-	"clean!",
-	"test!",
-	"build!",
-	"get!",
-	"algs!",
-	"rpacks!",
-	"perlmods!",
-	"iso-alg:s"
-	);
-    
+        "use-db!",
+        "source!",
+        "clean!",
+        "test!",
+        "build!",
+        "get!",
+        "algs!",
+        "rpacks!",
+        "perlmods!",
+        "iso-alg:s"
+    );
+
     #add --source options later..
     #print "Note that this installer attempts to install precompiled x86 binaries when possible. If ".
-    #	"this doesn't work for your architecture, please rerun the installer and invoke --source\n";
-    
+    #    "this doesn't work for your architecture, please rerun the installer and invoke --source\n";
+
     GetOptionsFromArray( \@args, \%ops, @opt_type_array );
     %ops = %{ dereference_options( \%ops ) };
 
-    if( $ops{"perlmods"} || 
-	$ops{"rpacks"}   ||
-	$ops{"algs"}     ||
-	$ops{"clean"}    ||
-	$ops{"get"}      ||
-	$ops{"build"}    ||
-	$ops{"test"}     ||
-	$ops{"source"}   ){
-	print "You specified a modular aspect of installation, so I will not run the entire " .
-	    "installation pipeline\n";
-	$ops{"all"} = 0;
+    if( $ops{"perlmods"} ||
+        $ops{"rpacks"}   ||
+        $ops{"algs"}     ||
+        $ops{"clean"}    ||
+        $ops{"get"}      ||
+        $ops{"build"}    ||
+        $ops{"test"}     ||
+        $ops{"source"} ){
+        print "You specified a modular aspect of installation, so I will not run the entire " .
+              "installation pipeline\n";
+        $ops{"all"} = 0;
     }
 
     #If we clean and want to build, we must also get.
-    if( $ops{"clean"} && 
-	$ops{"build"} ){
-	$ops{"get"} = 1;
+    if( $ops{"clean"} && $ops{"build"} ){
+        $ops{"get"} = 1;
     }
 
     if( $ops{"all"} ){
-	$ops{"perlmods"} = 1;
-	$ops{"rpacks"}   = 1;
-	$ops{"algs"}     = 1;
-	$ops{"clean"}    = 1;
-	$ops{"get"}      = 1;
-	$ops{"build"}    = 1;
-	$ops{"test"}     = 1;
+        $ops{"perlmods"} = 1;
+        $ops{"rpacks"}   = 1;
+        $ops{"algs"}     = 1;
+        $ops{"clean"}    = 1;
+        $ops{"get"}      = 1;
+        $ops{"build"}    = 1;
+        $ops{"test"}     = 1;
     }
     return \%ops;
 }
@@ -319,14 +320,14 @@ sub get_options{
 sub link_src{
     my $targets = shift; #must be path to target relative to shotmap root, semicolon sep list
     my $linkdir = shift;
-    
+
     print "creating symlinks...\n";
     chdir( $linkdir );
     foreach my $target( split( "\;", $targets ) ){
-	print( $linkdir . "\n");
-	print( $target  . "\n" );
-	system( "chmod a+x ${target}" );
-	system( "ln -s ${target}" );
+        print( $linkdir . "\n");
+        print( $target  . "\n" );
+        system( "chmod a+x ${target}" );
+        system( "ln -s ${target}" );
     }
     chdir( $ROOT );
     return;
@@ -340,69 +341,67 @@ sub parse_alg_data{
     open( IN, $file ) || die "Can't open $file for read: $!\n";
     my $name;
     while(<IN>){
-	chomp $_;
-	if( $_ =~ /^name/ ){
-	    (my $string, $name ) = split( "\:", $_ );
+        chomp $_;
+        if( $_ =~ /^name/ ){
+            (my $string, $name ) = split( "\:", $_ );
 
-	}  elsif( $_ =~ /^download/ ){
-	    check_name( $name );
-	    my ($string, $value ) = split( "\:", $_ );
-	    $alg_data->{$name}->{"download"} = $value;
-	    	   
-	} elsif( $_ =~ /^x86\:/ ){
-	    next if( $source );
-	    check_name( $name );
-	    #srcs may have : in the http/ftp string
-	    my ($string, $value, @rest ) = split( "\:", $_ );
-	    $value = join( ":", $value, @rest );
-	    $alg_data->{$name}->{"src"} = $value;
-	} elsif( $_ =~ /^src\:/ ){
-	    next unless( $source );
-	    check_name( $name );
-	    my ($string, $value, @rest ) = split( "\:", $_ );
-	    $value = join( ":", $value, @rest );
-	    $alg_data->{$name}->{"src"} = $value;
+        } elsif( $_ =~ /^download/ ){
+            check_name( $name );
+            my ($string, $value ) = split( "\:", $_ );
+            $alg_data->{$name}->{"download"} = $value;
+        } elsif( $_ =~ /^x86\:/ ){
+            next if( $source );
+            check_name( $name );
+            #srcs may have : in the http/ftp string
+            my ($string, $value, @rest ) = split( "\:", $_ );
+            $value = join( ":", $value, @rest );
+            $alg_data->{$name}->{"src"} = $value;
+        } elsif( $_ =~ /^src\:/ ){
+            next unless( $source );
+            check_name( $name );
+            my ($string, $value, @rest ) = split( "\:", $_ );
+            $value = join( ":", $value, @rest );
+            $alg_data->{$name}->{"src"} = $value;
+        } elsif( $_ =~ /^x86stem/ ){
+            next if( $source );
+            check_name( $name );
+            my ($string, $value ) = split( "\:", $_ );
+            $alg_data->{$name}->{"stem"} = $value;
+        } elsif( $_ =~ /^srcstem/ ){
+            next unless( $source );
+            check_name( $name );
+            my ($string, $value ) = split( "\:", $_ );
+            $alg_data->{$name}->{"stem"} = $value;
 
-	} elsif( $_ =~ /^x86stem/ ){
-	    next if( $source );
-	    check_name( $name );
-	    my ($string, $value ) = split( "\:", $_ );
-	    $alg_data->{$name}->{"stem"} = $value;
-	} elsif( $_ =~ /^srcstem/ ){
-	    next unless( $source );
-	    check_name( $name );
-	    my ($string, $value ) = split( "\:", $_ );
-	    $alg_data->{$name}->{"stem"} = $value;
+        } elsif( $_ =~ /^x86bins/ ){
+            next if( $source );
+            check_name( $name );
+            my ($string, $value ) = split( "\:", $_ );
+            $alg_data->{$name}->{"bins"} = $value;
+        } elsif( $_ =~ /^srcbins/ ){
+            next unless( $source );
+            check_name( $name );
+            my ($string, $value ) = split( "\:", $_ );
+            $alg_data->{$name}->{"bins"} = $value;
 
-	} elsif( $_ =~ /^x86bins/ ){
-	    next if( $source );
-	    check_name( $name );
-	    my ($string, $value ) = split( "\:", $_ );
-	    $alg_data->{$name}->{"bins"} = $value;
-	} elsif( $_ =~ /^srcbins/ ){
-	    next unless( $source );
-	    check_name( $name );
-	    my ($string, $value ) = split( "\:", $_ );
-	    $alg_data->{$name}->{"bins"} = $value;
+        } elsif( $_ =~ /^testcmds/ ){
+            next unless( $test );
+            check_name( $name );
+            my ($string, $value ) = split( "\:", $_ );
+            $alg_data->{$name}->{"build"} = $value;
+        } elsif( $_ =~ /^srccmds/ ){
+            next if( $test );
+            check_name( $name );
+            my ($string, $value ) = split( "\:", $_ );
+            $alg_data->{$name}->{"build"} = $value;
 
-	} elsif( $_ =~ /^testcmds/ ){
-	    next unless( $test );
-	    check_name( $name );
-	    my ($string, $value ) = split( "\:", $_ );
-	    $alg_data->{$name}->{"build"} = $value;
-	} elsif( $_ =~ /^srccmds/ ){
-	    next if( $test );
-	    check_name( $name );
-	    my ($string, $value ) = split( "\:", $_ );
-	    $alg_data->{$name}->{"build"} = $value;
-
-	} elsif( $_ =~ /^installed/ ){
-	    check_name( $name );
-	    my ($string, $value ) = split( "\:", $_ );
-	    $alg_data->{$name}->{"links"} = $value;
-	} elsif( $_ =~ m/^$/ ){
-	    $name    = undef;
-	}
+        } elsif( $_ =~ /^installed/ ){
+            check_name( $name );
+            my ($string, $value ) = split( "\:", $_ );
+            $alg_data->{$name}->{"links"} = $value;
+        } elsif( $_ =~ m/^$/ ){
+            $name    = undef;
+        }
     }
     close IN;
     return $alg_data;

--- a/install.pl
+++ b/install.pl
@@ -107,14 +107,14 @@ if( $algs ){
     print( "The requested items have been installed. If you haven't already, please be sure " .
 	   "to make the following additions to your ~/.bash_profile:\n" .
 	   "###################################\n"               . 
-	   "export PATH=\$PATH:\${root}/bin/\n"         .
-	   "export PERL5LIB=\$PERL5LIB:\${root}/lib/\n" .
+	   "export PATH=\$PATH:${root}/bin/\n"         .
+	   "export PERL5LIB=\$PERL5LIB:${root}/lib/\n" .
 	   "###################################\n" 
 	);
     print( "If you like, you can copy and paste the following command to automate the above entries:\n" . 
 	   "###################################\n"                                         . 
-	   "echo 'export PATH=\$PATH:\${root}/bin/' >> ~/.bash_profile\n"         .
-	   "echo 'export PERL5LIB=\$PERL5LIB:\${root}/lib/' >> ~/.bash_profile\n" .
+	   "echo 'export PATH=\$PATH:${root}/bin/' >> ~/.bash_profile\n"         .
+	   "echo 'export PERL5LIB=\$PERL5LIB:${root}/lib/' >> ~/.bash_profile\n" .
 	   "###################################\n" 
 	);
 }

--- a/installer_alg_data.txt
+++ b/installer_alg_data.txt
@@ -24,8 +24,8 @@ installed:bin/fastq-mcf
 
 name:prinseq
 download:wget
-x86:https://sourceforge.net/projects/prinseq/files/standalone/prinseq-lite-0.20.4.tar.gz/download
-src:https://sourceforge.net/projects/prinseq/files/standalone/prinseq-lite-0.20.4.tar.gz/download
+x86:http://downloads.sourceforge.net/project/prinseq/standalone/prinseq-lite-0.20.4.tar.gz
+src:http://downloads.sourceforge.net/project/prinseq/standalone/prinseq-lite-0.20.4.tar.gz
 x86stem:prinseq-lite-0.20.4
 srcstem:prinseq-lite-0.20.4
 x86bins:prinseq-lite.pl

--- a/installer_alg_data.txt
+++ b/installer_alg_data.txt
@@ -24,8 +24,8 @@ installed:bin/fastq-mcf
 
 name:prinseq
 download:wget
-x86:http://tcpdiag.dl.sourceforge.net/project/prinseq/standalone/prinseq-lite-0.20.4.tar.gz
-src:http://tcpdiag.dl.sourceforge.net/project/prinseq/standalone/prinseq-lite-0.20.4.tar.gz
+x86:https://sourceforge.net/projects/prinseq/files/standalone/prinseq-lite-0.20.4.tar.gz/download
+src:https://sourceforge.net/projects/prinseq/files/standalone/prinseq-lite-0.20.4.tar.gz/download
 x86stem:prinseq-lite-0.20.4
 srcstem:prinseq-lite-0.20.4
 x86bins:prinseq-lite.pl

--- a/installer_alg_data.txt
+++ b/installer_alg_data.txt
@@ -1,14 +1,14 @@
 name:trimmomatic
 download:wget
-x86:http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.35.zip
-src:http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.35.zip
-x86stem:Trimmomatic-0.35
-srcstem:Trimmomatic-0.35
-srcbins:trimmomatic-0.35.jar
-x86bins:trimmomatic-0.35.jar
+x86:http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.39.zip
+src:http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.39.zip
+x86stem:Trimmomatic-0.39
+srcstem:Trimmomatic-0.39
+srcbins:trimmomatic-0.39.jar
+x86bins:trimmomatic-0.39.jar
 testcmds:NA
 srccmds:NA
-installed:bin/trimmomatic-0.35.jar
+installed:bin/trimmomatic-0.39.jar
 
 name:eautils
 download:wget
@@ -18,8 +18,8 @@ x86stem:ea-utils.1.1.2-537
 srcstem:ea-utils.1.1.2-537
 srcbins:fastq-mcf
 x86bins:fastq-mcf
-testcmds:PREFIX=./ make install
-srccmds:PREFIX=./ make install
+testcmds:PREFIX=./ CFLAGS="-O3 -I." CPPFLAGS="-O3 -I." make install
+srccmds:PREFIX=./ CFLAGS="-O3 -I." CPPFLAGS="-O3 -I." make install
 installed:bin/fastq-mcf
 
 name:prinseq
@@ -36,10 +36,10 @@ installed:bin/prinseq-lite.pl
 
 name:bowtie2
 download:wget
-x86:http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.2.6/bowtie2-2.2.6-linux-x86_64.zip
-src:http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.2.6/bowtie2-2.2.6-linux-x86_64.zip
-x86stem:bowtie2-2.2.6
-srcstem:bowtie2-2.2.6
+x86:http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.3.5.1/bowtie2-2.3.5.1-linux-x86_64.zip
+src:http://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.3.5.1/bowtie2-2.3.5.1-linux-x86_64.zip
+x86stem:bowtie2-2.3.5.1-linux-x86_64
+srcstem:bowtie2-2.3.5.1-linux-x86_64
 x86bins:bowtie2;bowtie2-build
 srcbins:bowtie2;bowtie2-build
 testcmds:NA
@@ -84,8 +84,8 @@ installed:bin/seqret
 
 name:fastqc
 download:wget
-x86:http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.4.zip
-src:http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.4.zip
+x86:http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.8.zip
+src:http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.8.zip
 x86stem:FastQC
 srcstem:FastQC
 srcbins:fastqc
@@ -93,3 +93,15 @@ x86bins:fastqc
 testcmds:NA
 srccmds:NA
 installed:bin/fastqc
+
+name:bbduk
+download:wget
+x86:https://sourceforge.net/projects/bbmap/files/BBMap_38.69.tar.gz
+src:https://sourceforge.net/projects/bbmap/files/BBMap_38.69.tar.gz
+x86stem:bbmap
+srcstem:bbmap
+x86bins:bbduk.sh
+srcbins:bbduk.sh
+testcmds:NA
+srccmds:NA
+installed:bin/bbmap.sh

--- a/run_tests.pl
+++ b/run_tests.pl
@@ -136,6 +136,16 @@ if( system($cmd7) ){
     die( "GOT AN ERROR RUNNING  SHOTCLEANER!\n" );
 }
 
+my $out10 = File::Spec->catdir( $output, "paired_fastq-prinseq" );
+my $cmd10 = "perl ${master}/shotcleaner.pl -1 ${meta}/single/single.fq.gz -d $idx_db -n $host_name -m bowtie2 --nprocs $nprocs -o $out10 --adapt-path $ap --trim prinseq";
+if( $nocompress ){
+    $cmd10 .= " --nocompress ";
+}
+print $cmd10 . "\n";
+if( system($cmd10) ){
+    die( "GOT AN ERROR RUNNING  SHOTCLEANER!\n" );
+}
+
 
 
 print "TESTS COMPLETE!\n";

--- a/run_tests.pl
+++ b/run_tests.pl
@@ -36,6 +36,7 @@ my $ap = $master . "/pkg/Trimmomatic-0.39/adapters/NexteraPE-PE.fa";
 
 my $nocompress = 1;
 
+
 ####
 # BOWTIE2
 ####
@@ -102,6 +103,28 @@ if( system($cmd6) ){
     die( "GOT AN ERROR RUNNING  SHOTCLEANER!\n" );
 }
 
+##bbduk
+my $out8 = File::Spec->catdir( $output, "paired_fastq-bbduk" );
+my $cmd8 = "perl ${master}/shotcleaner.pl -1 ${meta}/paired/fastq/mate_1.fq.gz -2 ${meta}/paired/fastq/mate_2.fq.gz -d $idx_db -n $host_name -m bowtie2 --nprocs $nprocs -o $out8 --adapt-path $ap --trim bbduk";
+if( $nocompress ){
+    $cmd8 .= " --nocompress ";
+}
+print $cmd8 . "\n";
+if( system($cmd8) ){
+    die( "GOT AN ERROR RUNNING  SHOTCLEANER!\n" );
+}
+
+##atropos
+my $out9 = File::Spec->catdir( $output, "paired_fastq-atropos" );
+my $cmd9 = "perl ${master}/shotcleaner.pl -1 ${meta}/paired/fastq/mate_1.fq.gz -2 ${meta}/paired/fastq/mate_2.fq.gz -d $idx_db -n $host_name -m bowtie2 --nprocs $nprocs -o $out9 --adapt-path $ap --trim atropos";
+if( $nocompress ){
+    $cmd9 .= " --nocompress ";
+}
+print $cmd9 . "\n";
+if( system($cmd9) ){
+    die( "GOT AN ERROR RUNNING  SHOTCLEANER!\n" );
+}
+
 ##prinseq
 my $out7 = File::Spec->catdir( $output, "paired_fastq-prinseq" );
 my $cmd7 = "perl ${master}/shotcleaner.pl -1 ${meta}/paired/fastq/mate_1.fq.gz -2 ${meta}/paired/fastq/mate_2.fq.gz -d $idx_db -n $host_name -m bowtie2 --nprocs $nprocs -o $out7 --adapt-path $ap --trim prinseq";
@@ -112,5 +135,7 @@ print $cmd7 . "\n";
 if( system($cmd7) ){
     die( "GOT AN ERROR RUNNING  SHOTCLEANER!\n" );
 }
+
+
 
 print "TESTS COMPLETE!\n";

--- a/run_tests.pl
+++ b/run_tests.pl
@@ -1,5 +1,6 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
+use warnings;
 use strict;
 use File::Spec;
 use Cwd 'abs_path';
@@ -31,7 +32,7 @@ if( ! -d $output ) {
     `mkdir -p $output`;
 }
 
-my $ap = $master . "/pkg/Trimmomatic-0.35/adapters/NexteraPE-PE.fa";
+my $ap = $master . "/pkg/Trimmomatic-0.39/adapters/NexteraPE-PE.fa";
 
 my $nocompress = 1;
 
@@ -89,5 +90,27 @@ if( system($cmd5) ){
 
 ##################
 # ADD TESTS HERE
+#test on paired end data
+##fastq
+my $out6 = File::Spec->catdir( $output, "paired_fastq-trimmomatic" );
+my $cmd6 = "perl ${master}/shotcleaner.pl -1 ${meta}/paired/fastq/mate_1.fq.gz -2 ${meta}/paired/fastq/mate_2.fq.gz -d $idx_db -n $host_name -m bowtie2 --nprocs $nprocs -o $out6 --adapt-path $ap --trim trimmomatic";
+if( $nocompress ){
+    $cmd6 .= " --nocompress ";
+}
+print $cmd6 . "\n";
+if( system($cmd6) ){
+    die( "GOT AN ERROR RUNNING  SHOTCLEANER!\n" );
+}
+
+##prinseq
+my $out7 = File::Spec->catdir( $output, "paired_fastq-prinseq" );
+my $cmd7 = "perl ${master}/shotcleaner.pl -1 ${meta}/paired/fastq/mate_1.fq.gz -2 ${meta}/paired/fastq/mate_2.fq.gz -d $idx_db -n $host_name -m bowtie2 --nprocs $nprocs -o $out7 --adapt-path $ap --trim prinseq";
+if( $nocompress ){
+    $cmd7 .= " --nocompress ";
+}
+print $cmd7 . "\n";
+if( system($cmd7) ){
+    die( "GOT AN ERROR RUNNING  SHOTCLEANER!\n" );
+}
 
 print "TESTS COMPLETE!\n";

--- a/split_fastq.pl
+++ b/split_fastq.pl
@@ -1,5 +1,6 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
+use warnings;
 use strict;
 use File::Basename;
 use File::Path qw( make_path );


### PR DESCRIPTION
I updated the installers to pull the most recent versions of the software. 

I made several changes to the main script in f4dfba9 that fix old bugs as well as introduce two new trimmers to the pipeline. prinseq should work for trimming paired end and single end data now, and should derep both the forward and reverse read files for both fasta and fastq file types.

I updated compatibility for users who don't use `/usr/bin/perl` as their perl interpreter (e.g. in a conda env). This can be changed using the `$local_perl` variable. I also fixed some print statements so that the export messages are correct.

I removed a bunch of trailing whitespace as well.

Future work should likely be done to fix the mixed tabs/spaces and the tabstop=8 expectation for maintainability. Also want to consider using perlpod for a help message.

Lastly, before I realized the main script used tabs, I converted the mixed tab-space format from the install.pl to all spaces. Oops.